### PR TITLE
Add multi-account support for Claude integration

### DIFF
--- a/custom_components/hass_claude_usage/__init__.py
+++ b/custom_components/hass_claude_usage/__init__.py
@@ -170,15 +170,29 @@ def _parse_usage(raw: dict[str, Any]) -> dict[str, Any]:
         data["week_sonnet_usage_percent"] = seven_day_sonnet.get("utilization")
         data["week_sonnet_reset_time"] = seven_day_sonnet.get("resets_at")
 
+    # Overage/extra usage. The older API exposes this under "extra_usage" with
+    # credits in minor currency units; the newer API (mid-2026) moved it to a
+    # top-level "spend" object. Read whichever is enabled.
     extra = raw.get("extra_usage")
-    if extra:
-        data["extra_usage_enabled"] = extra.get("is_enabled", False)
+    spend = raw.get("spend")
+    if extra and extra.get("is_enabled"):
+        divisor = 10 ** extra.get("decimal_places", 2)
+        used = extra.get("used_credits")
+        limit = extra.get("monthly_limit")
+        data["extra_usage_enabled"] = True
         data["extra_usage_percent"] = extra.get("utilization")
-        data["extra_usage_credits"] = (
-            extra["used_credits"] / 100 if extra.get("used_credits") is not None else None
-        )
-        data["extra_usage_limit"] = (
-            extra["monthly_limit"] / 100 if extra.get("monthly_limit") is not None else None
-        )
+        data["extra_usage_credits"] = used / divisor if used is not None else None
+        data["extra_usage_limit"] = limit / divisor if limit is not None else None
+    elif spend and spend.get("enabled"):
+        used = spend.get("used") or {}
+        divisor = 10 ** used.get("exponent", 2)
+        amount = used.get("amount_minor")
+        limit = spend.get("limit")
+        data["extra_usage_enabled"] = True
+        data["extra_usage_percent"] = spend.get("percent")
+        data["extra_usage_credits"] = amount / divisor if amount is not None else None
+        data["extra_usage_limit"] = limit / divisor if limit is not None else None
+    elif extra is not None or spend is not None:
+        data["extra_usage_enabled"] = False
 
     return data

--- a/custom_components/hass_claude_usage/__init__.py
+++ b/custom_components/hass_claude_usage/__init__.py
@@ -184,14 +184,21 @@ def _parse_usage(raw: dict[str, Any]) -> dict[str, Any]:
         data["extra_usage_credits"] = used / divisor if used is not None else None
         data["extra_usage_limit"] = limit / divisor if limit is not None else None
     elif spend and spend.get("enabled"):
+        # In the "spend" schema both "used" and "limit" are money objects of the
+        # form {"amount_minor": int, "currency": str, "exponent": int}; "limit"
+        # may be null when no cap is set. "percent" is already 0-100.
         used = spend.get("used") or {}
-        divisor = 10 ** used.get("exponent", 2)
+        limit = spend.get("limit") or {}
+        used_divisor = 10 ** used.get("exponent", 2)
+        limit_divisor = 10 ** limit.get("exponent", 2)
         amount = used.get("amount_minor")
-        limit = spend.get("limit")
+        limit_amount = limit.get("amount_minor")
         data["extra_usage_enabled"] = True
         data["extra_usage_percent"] = spend.get("percent")
-        data["extra_usage_credits"] = amount / divisor if amount is not None else None
-        data["extra_usage_limit"] = limit / divisor if limit is not None else None
+        data["extra_usage_credits"] = amount / used_divisor if amount is not None else None
+        data["extra_usage_limit"] = (
+            limit_amount / limit_divisor if limit_amount is not None else None
+        )
     elif extra is not None or spend is not None:
         data["extra_usage_enabled"] = False
 

--- a/custom_components/hass_claude_usage/config_flow.py
+++ b/custom_components/hass_claude_usage/config_flow.py
@@ -197,9 +197,7 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
             account_email = account.get("email")
 
             # Get account name (prefer display name, fall back to email)
-            account_name = (
-                account.get("display_name") or account.get("full_name") or account_email
-            )
+            account_name = account.get("display_name") or account.get("full_name") or account_email
 
             # Get subscription level
             subscription_level = None
@@ -267,8 +265,20 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                         if self.source == SOURCE_RECONFIGURE
                         else self._get_reauth_entry()
                     )
+
+                    # Both reauth and reconfigure may re-point an entry at a
+                    # different account, so guard against two entries ending up
+                    # tracking the same account.
+                    new_unique_id = account_email or account_name
+                    if new_unique_id and any(
+                        other.entry_id != entry.entry_id and other.unique_id == new_unique_id
+                        for other in self._async_current_entries()
+                    ):
+                        return self.async_abort(reason="already_configured")
+
                     return self.async_update_reload_and_abort(
                         entry,
+                        unique_id=new_unique_id or entry.unique_id,
                         data_updates={
                             CONF_ACCESS_TOKEN: token_data["access_token"],
                             CONF_REFRESH_TOKEN: token_data.get("refresh_token", ""),

--- a/custom_components/hass_claude_usage/config_flow.py
+++ b/custom_components/hass_claude_usage/config_flow.py
@@ -13,6 +13,7 @@ from urllib.parse import urlencode
 import aiohttp
 import voluptuous as vol
 from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
@@ -216,6 +217,12 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle reauth when token is invalid."""
         return await self.async_step_reauth_confirm()
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle user-initiated reconfigure (e.g. re-auth as a different account)."""
+        return await self.async_step_reauth_confirm(user_input)
+
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -255,8 +262,13 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                         await self._fetch_account_info(token_data["access_token"])
                     )
 
+                    entry = (
+                        self._get_reconfigure_entry()
+                        if self.source == SOURCE_RECONFIGURE
+                        else self._get_reauth_entry()
+                    )
                     return self.async_update_reload_and_abort(
-                        self._get_reauth_entry(),
+                        entry,
                         data_updates={
                             CONF_ACCESS_TOKEN: token_data["access_token"],
                             CONF_REFRESH_TOKEN: token_data.get("refresh_token", ""),

--- a/custom_components/hass_claude_usage/config_flow.py
+++ b/custom_components/hass_claude_usage/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.helpers import aiohttp_client
 from .const import (
     API_BETA_HEADER,
     CONF_ACCESS_TOKEN,
+    CONF_ACCOUNT_EMAIL,
     CONF_ACCOUNT_NAME,
     CONF_EXPIRES_AT,
     CONF_REFRESH_TOKEN,
@@ -88,8 +89,8 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors["auth_code"] = "exchange_failed"
                 else:
                     # Fetch account info for display
-                    account_name, subscription_level = await self._fetch_account_info(
-                        token_data["access_token"]
+                    account_name, account_email, subscription_level = (
+                        await self._fetch_account_info(token_data["access_token"])
                     )
 
                     # Build title with name and subscription level
@@ -102,7 +103,8 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                             title_parts[-1] += ")"
                     title = " ".join(title_parts)
 
-                    await self.async_set_unique_id(DOMAIN)
+                    unique_id = account_email or account_name or DOMAIN
+                    await self.async_set_unique_id(unique_id)
                     self._abort_if_unique_id_configured()
                     return self.async_create_entry(
                         title=title,
@@ -111,6 +113,7 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                             CONF_REFRESH_TOKEN: token_data.get("refresh_token", ""),
                             CONF_EXPIRES_AT: time.time() + token_data.get("expires_in", 3600),
                             CONF_ACCOUNT_NAME: account_name,
+                            CONF_ACCOUNT_EMAIL: account_email,
                             CONF_SUBSCRIPTION_LEVEL: subscription_level,
                         },
                         options={
@@ -170,8 +173,10 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Token exchange request failed")
             return None
 
-    async def _fetch_account_info(self, access_token: str) -> tuple[str | None, str | None]:
-        """Fetch account name and subscription level from the profile API."""
+    async def _fetch_account_info(
+        self, access_token: str
+    ) -> tuple[str | None, str | None, str | None]:
+        """Fetch account name, email, and subscription level from the profile API."""
         try:
             session = aiohttp_client.async_get_clientsession(self.hass)
             resp = await session.get(
@@ -184,13 +189,15 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             if not resp.ok:
                 _LOGGER.warning("Failed to fetch account profile (%s)", resp.status)
-                return None, None
+                return None, None, None
             profile = await resp.json()
             account = profile.get("account", {})
 
-            # Get account name
+            account_email = account.get("email")
+
+            # Get account name (prefer display name, fall back to email)
             account_name = (
-                account.get("display_name") or account.get("full_name") or account.get("email")
+                account.get("display_name") or account.get("full_name") or account_email
             )
 
             # Get subscription level
@@ -200,10 +207,10 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
             elif account.get("has_claude_pro"):
                 subscription_level = "Pro"
 
-            return account_name, subscription_level
+            return account_name, account_email, subscription_level
         except (aiohttp.ClientError, KeyError):
             _LOGGER.exception("Error fetching account info")
-            return None, None
+            return None, None, None
 
     async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle reauth when token is invalid."""
@@ -244,8 +251,8 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                 if token_data is None:
                     errors["auth_code"] = "exchange_failed"
                 else:
-                    account_name, subscription_level = await self._fetch_account_info(
-                        token_data["access_token"]
+                    account_name, account_email, subscription_level = (
+                        await self._fetch_account_info(token_data["access_token"])
                     )
 
                     return self.async_update_reload_and_abort(
@@ -255,6 +262,7 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                             CONF_REFRESH_TOKEN: token_data.get("refresh_token", ""),
                             CONF_EXPIRES_AT: time.time() + token_data.get("expires_in", 3600),
                             CONF_ACCOUNT_NAME: account_name,
+                            CONF_ACCOUNT_EMAIL: account_email,
                             CONF_SUBSCRIPTION_LEVEL: subscription_level,
                         },
                     )

--- a/custom_components/hass_claude_usage/const.py
+++ b/custom_components/hass_claude_usage/const.py
@@ -23,6 +23,7 @@ CONF_REFRESH_TOKEN = "refresh_token"
 CONF_EXPIRES_AT = "expires_at"
 CONF_UPDATE_INTERVAL = "update_interval"
 CONF_ACCOUNT_NAME = "account_name"
+CONF_ACCOUNT_EMAIL = "account_email"
 CONF_SUBSCRIPTION_LEVEL = "subscription_level"
 
 # Sensor definitions: (key, name, unit, icon, device_class)

--- a/custom_components/hass_claude_usage/manifest.json
+++ b/custom_components/hass_claude_usage/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/trickv/hass-claude-usage/issues",
   "requirements": [],
   "single_config_entry": false,
-  "version": "6"
+  "version": "7"
 }

--- a/custom_components/hass_claude_usage/manifest.json
+++ b/custom_components/hass_claude_usage/manifest.json
@@ -7,5 +7,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/trickv/hass-claude-usage/issues",
   "requirements": [],
+  "single_config_entry": false,
   "version": "6"
 }

--- a/custom_components/hass_claude_usage/strings.json
+++ b/custom_components/hass_claude_usage/strings.json
@@ -21,7 +21,7 @@
       "exchange_failed": "Failed to exchange code for tokens. Please try again."
     },
     "abort": {
-      "already_configured": "Claude Usage is already configured",
+      "already_configured": "This Claude account is already configured",
       "reauth_successful": "Re-authentication was successful"
     }
   },

--- a/custom_components/hass_claude_usage/strings.json
+++ b/custom_components/hass_claude_usage/strings.json
@@ -10,7 +10,7 @@
       },
       "reauth_confirm": {
         "title": "Re-authenticate with Claude",
-        "description": "Your Claude authentication has expired or been revoked. [Open this link]({url}) to log in again with Anthropic.\n\nAfter authorizing, paste the new authorization code below.",
+        "description": "Re-authenticate this entry (your token expired or was revoked, or you want to switch to a different Claude account). [Open this link]({url}) to log in with Anthropic — make sure you are logged in as the account you want this entry to track. After authorizing, paste the new authorization code below.",
         "data": {
           "auth_code": "Authorization Code"
         }
@@ -22,7 +22,8 @@
     },
     "abort": {
       "already_configured": "This Claude account is already configured",
-      "reauth_successful": "Re-authentication was successful"
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Re-authentication was successful"
     }
   },
   "options": {

--- a/custom_components/hass_claude_usage/translations/en.json
+++ b/custom_components/hass_claude_usage/translations/en.json
@@ -21,7 +21,7 @@
       "exchange_failed": "Failed to exchange code for tokens. Please try again."
     },
     "abort": {
-      "already_configured": "Claude Usage is already configured",
+      "already_configured": "This Claude account is already configured",
       "reauth_successful": "Re-authentication was successful"
     }
   },

--- a/custom_components/hass_claude_usage/translations/en.json
+++ b/custom_components/hass_claude_usage/translations/en.json
@@ -10,7 +10,7 @@
       },
       "reauth_confirm": {
         "title": "Re-authenticate with Claude",
-        "description": "Your Claude authentication has expired or been revoked. [Open this link]({url}) to log in again with Anthropic.\n\nAfter authorizing, paste the new authorization code below.",
+        "description": "Re-authenticate this entry (your token expired or was revoked, or you want to switch to a different Claude account). [Open this link]({url}) to log in with Anthropic — make sure you are logged in as the account you want this entry to track. After authorizing, paste the new authorization code below.",
         "data": {
           "auth_code": "Authorization Code"
         }
@@ -22,7 +22,8 @@
     },
     "abort": {
       "already_configured": "This Claude account is already configured",
-      "reauth_successful": "Re-authentication was successful"
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Re-authentication was successful"
     }
   },
   "options": {


### PR DESCRIPTION
## Add multi-account support

Removes the single-account restriction so users can add multiple Claude accounts (e.g. a personal Pro account and an enterprise account for my use case) as separate integration entries, each with their own set of sensors and device.

## Changes

- **`manifest.json`** — Added `"single_config_entry": false`. This is required in HA 2024.x+ to allow the integration to be added more than once via the UI. Without it, HA blocks the config flow entirely when an entry already exists.

- **`config_flow.py`** — Replaced `async_set_unique_id(DOMAIN)` with a per-account unique ID derived from the account's email address (falls back to display name, then domain). The profile API call now also extracts the email separately from the display name so it can serve as a reliable unique identifier. Both the initial setup flow and the reauth flow are updated accordingly.

- **`const.py`** — Added `CONF_ACCOUNT_EMAIL` constant and stores the email in the config entry data.

- **`strings.json` / `translations/en.json`** — Updated the "already configured" abort message from *"Claude Usage is already configured"* to *"This Claude account is already configured"*, which is accurate now that the check is per-account rather than per-integration.

## How it works

Previously the unique ID for every config entry was the static string `"hass_claude_usage"`, so adding a second account always hit the duplicate check. Now the unique ID is the account email (e.g. `you@gmail.com` vs `you@company.com`), so different accounts are treated as distinct entries. Attempting to add the same account twice still aborts with an appropriate message. Each account gets its own device and coordinator — no other changes were needed for sensor isolation since that was already driven by `entry.entry_id`.

It works great for my two accounts and shows credits and updates on both
<img width="1061" height="557" alt="image" src="https://github.com/user-attachments/assets/6a40fded-d7c0-4b14-9fa6-ec663824b9df" />
