### PR TITLE
Remove dead opencode-anthropic-auth link from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,7 +306,6 @@ mypy custom_components/hass_claude_usage/
 
 ### Research Sources
 
-- [Claude OAuth implementation (opencode-anthropic-auth)](https://github.com/anomalyco/opencode-anthropic-auth/blob/master/index.mjs)
 - [OpenCode OAuth usage dashboard feature request](https://github.com/anomalyco/opencode/issues/8911)
 - [Claude Code source (local installation)](file://~/.nvm/versions/node/v22.18.0/lib/node_modules/@anthropic-ai/claude-code/cli.js)
 - [Home Assistant DataUpdateCoordinator docs](https://developers.home-assistant.io/docs/integration_fetching_data)


### PR DESCRIPTION
## Problem

The **Validate** workflow's *Markdown Link Check* job fails on every push to `master`:

```
FILE: ./AGENTS.md
[✖] https://github.com/anomalyco/opencode-anthropic-auth/blob/master/index.mjs → Status: 404
ERROR: 1 dead links found!
```

The `anomalyco/opencode-anthropic-auth` repo now 404s at the root (deleted/renamed/private), so the link can't be repaired — only removed. This is unrelated to recent changes; it surfaced on the merge of #2.

## Fix

Remove the dead reference link from the Research Sources section of `AGENTS.md`. The descriptive bullet under "Related Projects" is left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)