### PR TITLE
feat: support multiple Claude accounts

### DIFF
--- a/custom_components/hass_claude_usage/__init__.py
+++ b/custom_components/hass_claude_usage/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import (
     API_BETA_HEADER,
     CONF_ACCESS_TOKEN,
+    CONF_ACCOUNT_ID,
     CONF_EXPIRES_AT,
     CONF_REFRESH_TOKEN,
     CONF_UPDATE_INTERVAL,
@@ -25,6 +26,7 @@ from .const import (
     DOMAIN,
     OAUTH_CLIENT_ID,
     OAUTH_TOKEN_URL,
+    PROFILE_API_URL,
     USAGE_API_URL,
 )
 
@@ -33,6 +35,111 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.SENSOR]
 
 type ClaudeUsageConfigEntry = ConfigEntry[ClaudeUsageCoordinator]
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ClaudeUsageConfigEntry) -> bool:
+    """Migrate config entry to a new version."""
+    if entry.version == 1:
+        _LOGGER.debug("Migrating Claude Usage config entry from v1 to v2")
+        account_id = await _fetch_account_id_for_migration(hass, entry)
+
+        new_data = {**entry.data, CONF_ACCOUNT_ID: account_id}
+        hass.config_entries.async_update_entry(
+            entry,
+            data=new_data,
+            unique_id=account_id,
+            version=2,
+        )
+        _LOGGER.info("Migrated Claude Usage config entry to v2 (account_id=%s)", account_id)
+    return True
+
+
+async def _fetch_account_id_for_migration(
+    hass: HomeAssistant,
+    entry: ClaudeUsageConfigEntry,
+) -> str:
+    """Try to resolve a stable account ID during v1→v2 migration.
+
+    Attempts: current token → refresh token → fallback to entry_id sentinel.
+    Reauth knows to replace the entry_id sentinel with a real account ID.
+    """
+    session = aiohttp_client.async_get_clientsession(hass)
+    access_token = entry.data.get(CONF_ACCESS_TOKEN)
+
+    # Try current token first, then refresh if expired
+    for attempt in ("current", "refreshed"):
+        if not access_token:
+            break
+        try:
+            resp = await session.get(
+                PROFILE_API_URL,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "anthropic-beta": API_BETA_HEADER,
+                },
+                timeout=aiohttp.ClientTimeout(total=15),
+            )
+            if resp.ok:
+                profile = await resp.json()
+                account = profile.get("account") or {}
+                account_id = (
+                    account.get("uuid")
+                    or account.get("id")
+                    or account.get("email")
+                )
+                if account_id:
+                    return account_id
+
+            # 401 on first attempt — try refreshing
+            if resp.status == 401 and attempt == "current":
+                access_token = await _refresh_token_for_migration(hass, session, entry)
+                continue
+            break
+        except Exception:
+            _LOGGER.warning("Could not fetch profile during migration (attempt=%s)", attempt)
+            break
+
+    # ponytail: fallback sentinel — reauth replaces this with real account_id
+    _LOGGER.warning("Migration falling back to entry_id as account_id placeholder")
+    return entry.entry_id
+
+
+async def _refresh_token_for_migration(
+    hass: HomeAssistant,
+    session: aiohttp.ClientSession,
+    entry: ClaudeUsageConfigEntry,
+) -> str | None:
+    """Attempt token refresh during migration. Returns new access_token or None."""
+    refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
+    if not refresh_token:
+        return None
+    try:
+        resp = await session.post(
+            OAUTH_TOKEN_URL,
+            json={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": OAUTH_CLIENT_ID,
+            },
+            timeout=aiohttp.ClientTimeout(total=15),
+        )
+        if not resp.ok:
+            return None
+        token_data = await resp.json()
+        new_token = token_data.get("access_token")
+        if new_token:
+            # Persist refreshed tokens
+            new_data = {
+                **entry.data,
+                CONF_ACCESS_TOKEN: new_token,
+                CONF_REFRESH_TOKEN: token_data.get("refresh_token", refresh_token),
+                CONF_EXPIRES_AT: time.time() + token_data.get("expires_in", 3600),
+            }
+            hass.config_entries.async_update_entry(entry, data=new_data)
+        return new_token
+    except Exception:
+        _LOGGER.warning("Token refresh failed during migration")
+        return None
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ClaudeUsageConfigEntry) -> bool:

--- a/custom_components/hass_claude_usage/config_flow.py
+++ b/custom_components/hass_claude_usage/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.helpers import aiohttp_client
 from .const import (
     API_BETA_HEADER,
     CONF_ACCESS_TOKEN,
+    CONF_ACCOUNT_ID,
     CONF_ACCOUNT_NAME,
     CONF_EXPIRES_AT,
     CONF_REFRESH_TOKEN,
@@ -45,7 +46,7 @@ _LOGGER = logging.getLogger(__name__)
 class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Claude Usage."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -87,36 +88,40 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                 if token_data is None:
                     errors["auth_code"] = "exchange_failed"
                 else:
-                    # Fetch account info for display
-                    account_name, subscription_level = await self._fetch_account_info(
-                        token_data["access_token"]
+                    # Fetch account info for display and dedup
+                    account_id, account_name, subscription_level = (
+                        await self._fetch_account_info(token_data["access_token"])
                     )
 
-                    # Build title with name and subscription level
-                    title_parts = ["Claude Usage"]
-                    if account_name:
-                        title_parts.append(f"({account_name}")
-                        if subscription_level:
-                            title_parts.append(f"- {subscription_level})")
-                        else:
-                            title_parts[-1] += ")"
-                    title = " ".join(title_parts)
+                    if not account_id:
+                        errors["auth_code"] = "exchange_failed"
+                    else:
+                        # Build title with name and subscription level
+                        title_parts = ["Claude Usage"]
+                        if account_name:
+                            title_parts.append(f"({account_name}")
+                            if subscription_level:
+                                title_parts.append(f"- {subscription_level})")
+                            else:
+                                title_parts[-1] += ")"
+                        title = " ".join(title_parts)
 
-                    await self.async_set_unique_id(DOMAIN)
-                    self._abort_if_unique_id_configured()
-                    return self.async_create_entry(
-                        title=title,
-                        data={
-                            CONF_ACCESS_TOKEN: token_data["access_token"],
-                            CONF_REFRESH_TOKEN: token_data.get("refresh_token", ""),
-                            CONF_EXPIRES_AT: time.time() + token_data.get("expires_in", 3600),
-                            CONF_ACCOUNT_NAME: account_name,
-                            CONF_SUBSCRIPTION_LEVEL: subscription_level,
-                        },
-                        options={
-                            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-                        },
-                    )
+                        await self.async_set_unique_id(account_id)
+                        self._abort_if_unique_id_configured()
+                        return self.async_create_entry(
+                            title=title,
+                            data={
+                                CONF_ACCESS_TOKEN: token_data["access_token"],
+                                CONF_REFRESH_TOKEN: token_data.get("refresh_token", ""),
+                                CONF_EXPIRES_AT: time.time() + token_data.get("expires_in", 3600),
+                                CONF_ACCOUNT_ID: account_id,
+                                CONF_ACCOUNT_NAME: account_name,
+                                CONF_SUBSCRIPTION_LEVEL: subscription_level,
+                            },
+                            options={
+                                CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+                            },
+                        )
 
         return self.async_show_form(
             step_id="user",
@@ -169,8 +174,11 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Token exchange request failed")
             return None
 
-    async def _fetch_account_info(self, access_token: str) -> tuple[str | None, str | None]:
-        """Fetch account name and subscription level from the profile API."""
+    async def _fetch_account_info(
+        self,
+        access_token: str,
+    ) -> tuple[str | None, str | None, str | None]:
+        """Fetch account id, name, and subscription level from the profile API."""
         try:
             session = aiohttp_client.async_get_clientsession(self.hass)
             resp = await session.get(
@@ -183,26 +191,33 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             if not resp.ok:
                 _LOGGER.warning("Failed to fetch account profile (%s)", resp.status)
-                return None, None
+                return None, None, None
             profile = await resp.json()
             account = profile.get("account", {})
 
-            # Get account name
+            _LOGGER.debug("Profile account keys: %s", list(account.keys()))
+
+            # Stable unique identifier — try uuid/id first, fall back to email
+            account_id = (
+                account.get("uuid") or account.get("id") or account.get("email")
+            )
+
+            # Display name
             account_name = (
                 account.get("display_name") or account.get("full_name") or account.get("email")
             )
 
-            # Get subscription level
+            # Subscription level
             subscription_level = None
             if account.get("has_claude_max"):
                 subscription_level = "Max"
             elif account.get("has_claude_pro"):
                 subscription_level = "Pro"
 
-            return account_name, subscription_level
+            return account_id, account_name, subscription_level
         except (aiohttp.ClientError, KeyError):
             _LOGGER.exception("Error fetching account info")
-            return None, None
+            return None, None, None
 
     async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle reauth when token is invalid."""
@@ -243,20 +258,37 @@ class ClaudeUsageConfigFlow(ConfigFlow, domain=DOMAIN):
                 if token_data is None:
                     errors["auth_code"] = "exchange_failed"
                 else:
-                    account_name, subscription_level = await self._fetch_account_info(
-                        token_data["access_token"]
+                    account_id, account_name, subscription_level = (
+                        await self._fetch_account_info(token_data["access_token"])
                     )
 
-                    return self.async_update_reload_and_abort(
-                        self._get_reauth_entry(),
-                        data_updates={
-                            CONF_ACCESS_TOKEN: token_data["access_token"],
-                            CONF_REFRESH_TOKEN: token_data.get("refresh_token", ""),
-                            CONF_EXPIRES_AT: time.time() + token_data.get("expires_in", 3600),
-                            CONF_ACCOUNT_NAME: account_name,
-                            CONF_SUBSCRIPTION_LEVEL: subscription_level,
-                        },
-                    )
+                    if not account_id:
+                        errors["auth_code"] = "exchange_failed"
+                    else:
+                        reauth_entry = self._get_reauth_entry()
+                        stored_id = reauth_entry.data.get(CONF_ACCOUNT_ID)
+
+                        # Allow replacing migration sentinel (entry_id placeholder)
+                        # but block reauth with a genuinely different account
+                        if (
+                            stored_id
+                            and stored_id != reauth_entry.entry_id
+                            and account_id != stored_id
+                        ):
+                            return self.async_abort(reason="account_mismatch")
+
+                        return self.async_update_reload_and_abort(
+                            reauth_entry,
+                            unique_id=account_id,
+                            data_updates={
+                                CONF_ACCESS_TOKEN: token_data["access_token"],
+                                CONF_REFRESH_TOKEN: token_data.get("refresh_token", ""),
+                                CONF_EXPIRES_AT: time.time() + token_data.get("expires_in", 3600),
+                                CONF_ACCOUNT_ID: account_id,
+                                CONF_ACCOUNT_NAME: account_name,
+                                CONF_SUBSCRIPTION_LEVEL: subscription_level,
+                            },
+                        )
 
         return self.async_show_form(
             step_id="reauth_confirm",

--- a/custom_components/hass_claude_usage/const.py
+++ b/custom_components/hass_claude_usage/const.py
@@ -22,6 +22,7 @@ CONF_ACCESS_TOKEN = "access_token"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_EXPIRES_AT = "expires_at"
 CONF_UPDATE_INTERVAL = "update_interval"
+CONF_ACCOUNT_ID = "account_id"
 CONF_ACCOUNT_NAME = "account_name"
 CONF_SUBSCRIPTION_LEVEL = "subscription_level"
 

--- a/custom_components/hass_claude_usage/manifest.json
+++ b/custom_components/hass_claude_usage/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/trickv/hass-claude-usage/issues",
   "requirements": [],
-  "version": "6"
+  "version": "7"
 }

--- a/custom_components/hass_claude_usage/strings.json
+++ b/custom_components/hass_claude_usage/strings.json
@@ -21,7 +21,8 @@
       "exchange_failed": "Failed to exchange code for tokens. Please try again."
     },
     "abort": {
-      "already_configured": "Claude Usage is already configured",
+      "already_configured": "This Claude account is already configured",
+      "account_mismatch": "Re-authentication must use the same Claude account",
       "reauth_successful": "Re-authentication was successful"
     }
   },

--- a/custom_components/hass_claude_usage/translations/en.json
+++ b/custom_components/hass_claude_usage/translations/en.json
@@ -21,7 +21,8 @@
       "exchange_failed": "Failed to exchange code for tokens. Please try again."
     },
     "abort": {
-      "already_configured": "Claude Usage is already configured",
+      "already_configured": "This Claude account is already configured",
+      "account_mismatch": "Re-authentication must use the same Claude account",
       "reauth_successful": "Re-authentication was successful"
     }
   },


### PR DESCRIPTION
Use per-account unique_id (uuid/id/email) instead of fixed DOMAIN string, allowing multiple Claude accounts on a single HA instance.

- config_flow VERSION 1→2 with async_migrate_entry
- Migration attempts token refresh before falling back to entry_id sentinel
- Reauth guards against account mismatch, allows replacing sentinel
- manifest version 6→7